### PR TITLE
Fixed typo in sequence modules, 'Magento_Widgets' doesn't exist, it h…

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -15,7 +15,7 @@
             <module name="Magento_Backend"/>
             <module name="Magento_Cms"/>
             <module name="Magento_Ui"/>
-            <module name="Magento_Widgets"/>
+            <module name="Magento_Widget"/>
             <module name="Magento_CmsStaging"/>
         </sequence>
     </module>


### PR DESCRIPTION
…as to be 'Magento_Widget'.

In our case, this typo caused javascript warnings to be outputted when trying to use widgets in the backend. But this only happens when 'Magento_Widget' is underneath 'Magenerds_PageDesigner' in the `app/etc/config.php` file. This PR fixes this problem.