### PR TITLE
Fixes issue 23: make sure cms block content is correct in Magento 2.2.4 and 2.2.5

### DIFF
--- a/Plugin/Cms/Model/Block/BlockPlugin.php
+++ b/Plugin/Cms/Model/Block/BlockPlugin.php
@@ -10,7 +10,6 @@
 namespace Magenerds\PageDesigner\Plugin\Cms\Model\Block;
 
 use Magenerds\PageDesigner\Constants;
-use Magento\Cms\Api\Data\BlockInterface;
 use Magenerds\PageDesigner\Utils\HtmlRendererInterface;
 use Magento\Cms\Model\Block;
 use Magento\Cms\Model\ResourceModel\Block as BlockResource;
@@ -47,7 +46,7 @@ final class BlockPlugin
      * Manipulates the Block entity before it is saved
      *
      * @param BlockResource $blockResource
-     * @param BlockInterface|Block $block
+     * @param Block $block
      * @param array $arguments
      */
     public function beforeSave(BlockResource $blockResource, Block $block, ... $arguments) // NOSONAR

--- a/Plugin/Cms/Model/Block/BlockPlugin.php
+++ b/Plugin/Cms/Model/Block/BlockPlugin.php
@@ -9,8 +9,11 @@
 
 namespace Magenerds\PageDesigner\Plugin\Cms\Model\Block;
 
+use Magenerds\PageDesigner\Constants;
 use Magento\Cms\Api\Data\BlockInterface;
 use Magenerds\PageDesigner\Utils\HtmlRendererInterface;
+use Magento\Cms\Model\Block;
+use Magento\Cms\Model\ResourceModel\Block as BlockResource;
 
 /**
  * Class BlockPlugin
@@ -43,13 +46,14 @@ final class BlockPlugin
     /**
      * Manipulates the Block entity before it is saved
      *
-     * @param BlockInterface $block
+     * @param BlockResource $blockResource
+     * @param BlockInterface|Block $block
      * @param array $arguments
      */
-    public function beforeSave(BlockInterface $block, ... $arguments) // NOSONAR
+    public function beforeSave(BlockResource $blockResource, Block $block, ... $arguments) // NOSONAR
     {
         /** @noinspection PhpUndefinedMethodInspection */
-        $json = $block->getPageDesignerJson();
+        $json = $block->getData(Constants::ATTR_PAGE_DESIGNER_JSON);
 
         if (strlen(trim($json)) > 0) {
             $block->setContent($this->htmlRenderer->toHtml($json));

--- a/Plugin/Cms/Model/Page/PagePlugin.php
+++ b/Plugin/Cms/Model/Page/PagePlugin.php
@@ -10,7 +10,6 @@
 namespace Magenerds\PageDesigner\Plugin\Cms\Model\Page;
 
 use Magenerds\PageDesigner\Constants;
-use Magento\Cms\Api\Data\PageInterface;
 use Magenerds\PageDesigner\Utils\HtmlRendererInterface;
 use Magento\Cms\Model\Page;
 use Magento\Cms\Model\ResourceModel\Page as PageResource;
@@ -47,7 +46,7 @@ final class PagePlugin
      * Manipulates the Page entity before it is saved
      *
      * @param PageResource $pageResource
-     * @param PageInterface|Page $page
+     * @param Page $page
      * @param array $arguments
      */
     public function beforeSave(PageResource $pageResource, Page $page, ... $arguments) // NOSONAR

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -27,7 +27,7 @@
                 type="Magenerds\PageDesigner\Plugin\Cms\Model\Page\PagePlugin" sortOrder="100"/>
     </type>
 
-    <type name="Magento\Cms\Model\Block">
+    <type name="Magento\Cms\Model\ResourceModel\Block">
         <plugin name="Magenerds_PageDesigner::cmsBlockRenderJson"
                 type="Magenerds\PageDesigner\Plugin\Cms\Model\Block\BlockPlugin" sortOrder="100"/>
     </type>


### PR DESCRIPTION
See: https://github.com/Magenerds/PageDesigner/issues/23#issuecomment-414408049

Additionally removed the `PageInterface` and `BlockInterface` types from the doc blocks, since they don't define a `getData` method, so didn't make sense that they were referenced I think.

Tested in Magento 2.2.3 and Magento 2.2.5
~Attempted to test in Magento 2.1.14 but ran against another bug which was reported over here: https://github.com/Magenerds/PageDesigner/issues/22~
Also tested in Magento 2.1.7 and 2.1.14 after fixing https://github.com/Magenerds/PageDesigner/issues/22 in https://github.com/Magenerds/PageDesigner/pull/25

Further: I don't know how you should communicate to your users how to fix their current issues. Which can be:
- new blocks have no content
- existing blocks can have outdated content

The simple fix is to re-save those blocks which are incorrect after this fix was installed. Maybe add something like that to the readme?

But if you want to automate it, you can probably also write an UpgradeData script which runs over all blocks and re-saves all `content` columns from the `page_designer_json` column... (not sure if this is a good idea, it might in theory accidentally remove content when a block already had content before this module was installed?)