### PR TITLE
Fixes issue 22: put formElement at the correct place in the ui component .xml files.

### DIFF
--- a/view/adminhtml/ui_component/cms_block_form.xml
+++ b/view/adminhtml/ui_component/cms_block_form.xml
@@ -31,10 +31,11 @@
             </argument>
         </field>
         <!-- page designer -->
-        <field name="page-designer" formElement="component">
+        <field name="page-designer">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="label" xsi:type="string"/>
+                    <item name="formElement" xsi:type="string">component</item>
                     <item name="source" xsi:type="string">block</item>
                     <item name="dataScope" xsi:type="string">page_designer_json</item>
                     <item name="component" xsi:type="string">Magenerds_PageDesigner/js/page_designer</item>

--- a/view/adminhtml/ui_component/cms_page_form.xml
+++ b/view/adminhtml/ui_component/cms_page_form.xml
@@ -31,10 +31,11 @@
             </argument>
         </field>
         <!-- page designer -->
-        <field name="page-designer" formElement="component">
+        <field name="page-designer">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="label" xsi:type="string"/>
+                    <item name="formElement" xsi:type="string">component</item>
                     <item name="source" xsi:type="string">page</item>
                     <item name="dataScope" xsi:type="string">page_designer_json</item>
                     <item name="component" xsi:type="string">Magenerds_PageDesigner/js/page_designer</item>

--- a/view/adminhtml/ui_component/cmsstaging_block_update_form.xml
+++ b/view/adminhtml/ui_component/cmsstaging_block_update_form.xml
@@ -31,10 +31,11 @@
             </argument>
         </field>
         <!-- page designer -->
-        <field name="page-designer" formElement="component">
+        <field name="page-designer">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="label" xsi:type="string"/>
+                    <item name="formElement" xsi:type="string">component</item>
                     <item name="source" xsi:type="string">block</item>
                     <item name="dataScope" xsi:type="string">page_designer_json</item>
                     <item name="component" xsi:type="string">Magenerds_PageDesigner/js/page_designer</item>

--- a/view/adminhtml/ui_component/cmsstaging_page_update_form.xml
+++ b/view/adminhtml/ui_component/cmsstaging_page_update_form.xml
@@ -31,10 +31,11 @@
             </argument>
         </field>
         <!-- page designer -->
-        <field name="page-designer" formElement="component">
+        <field name="page-designer">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="label" xsi:type="string"/>
+                    <item name="formElement" xsi:type="string">component</item>
                     <item name="source" xsi:type="string">page</item>
                     <item name="dataScope" xsi:type="string">page_designer_json</item>
                     <item name="component" xsi:type="string">Magenerds_PageDesigner/js/page_designer</item>


### PR DESCRIPTION
See: https://github.com/Magenerds/PageDesigner/issues/22

Watch out: I don't know anything about UI components, but looking [a few lines higher in the file](https://github.com/Magenerds/PageDesigner/blob/3.1.0/view/adminhtml/ui_component/cms_block_form.xml#L28) and I noticed that the `formElement` was declared differently. So changed it, and that  fixed the issue apparently.

Problem only occurred in Magento 2.1.x, not in 2.2.x
Tested fix in Magento 2.1.7, 2.1.14, 2.2.3 and 2.2.5 and seems to cause no problems in any of those versions.