### PR TITLE
Fixes PHP 8.1 deprecated function calls with passing 'null' to 'trim'…

### DIFF
--- a/Plugin/Cms/Model/Block/BlockPlugin.php
+++ b/Plugin/Cms/Model/Block/BlockPlugin.php
@@ -60,7 +60,7 @@ final class BlockPlugin
     {
         /** @noinspection PhpUndefinedMethodInspection */
         $json = $block->getData(Constants::ATTR_PAGE_DESIGNER_JSON);
-        if (strlen(trim($json)) > 0) {
+        if (is_string($json) && strlen(trim($json)) > 0) {
             $block->setContent($this->htmlRenderer->toHtml($json, $block->getData(Constants::ATTR_PAGE_DESIGNER_REMOVE)));
         }
     }

--- a/Plugin/Cms/Model/Page/PagePlugin.php
+++ b/Plugin/Cms/Model/Page/PagePlugin.php
@@ -60,7 +60,7 @@ final class PagePlugin
     {
         /** @noinspection PhpUndefinedMethodInspection */
         $json = $page->getData(Constants::ATTR_PAGE_DESIGNER_JSON);
-        if (strlen(trim($json)) > 0) {
+        if (is_string($json) && strlen(trim($json)) > 0) {
             $page->setContent($this->htmlRenderer->toHtml($json, $page->getData(Constants::ATTR_PAGE_DESIGNER_REMOVE)));
         }
     }


### PR DESCRIPTION
… which is no longer allowed.


Noticed this while preparing a project to be setup with Magento 2.4.5 and PHP 8.1 with PageDesigner installed and PageBuilder not installed.

Following errors popped up during `bin/magento setup:install --cleanup-database ...` on a clean database:
```
Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/magenerds/pagedesigner/Plugin/Cms/Model/Page/PagePlugin.php on line 63

Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/magenerds/pagedesigner/Plugin/Cms/Model/Block/BlockPlugin.php on line 63
```

See `Passing null to non-nullable parameters of built-in functions` section in https://www.php.net/manual/en/migration81.deprecated.php

This PR fixes this by first double checking if the `$json` is actually a string and not something else, like `null`.